### PR TITLE
Add docs for custom notification channels

### DIFF
--- a/docs/configuring-notifications/adding-extra-notification-channels.md
+++ b/docs/configuring-notifications/adding-extra-notification-channels.md
@@ -1,0 +1,52 @@
+---
+title: Adding extra notification channels
+weight: 3
+---
+
+By default the package can send notifications via mail or Slack. You can easily add any other
+[Laravel notification channel](https://laravel-notification-channels.com) such as Telegram or Pusher.
+
+### 1. Install the notification channel driver
+
+For example, to use Pusher push notifications install the channel package:
+
+```bash
+composer require laravel-notification-channels/pusher-push-notifications
+```
+
+### 2. Create your own notification class
+
+Extend `Spatie\Health\Notifications\CheckFailedNotification` and implement a method
+for the channel you want to use.
+
+```php
+namespace App\Notifications;
+
+use Spatie\Health\Notifications\CheckFailedNotification as BaseNotification;
+use NotificationChannels\PusherPushNotifications\Message;
+
+class CheckFailedNotification extends BaseNotification
+{
+    public function toPushNotification($notifiable)
+    {
+        return Message::create()
+            ->iOS()
+            ->badge(1)
+            ->sound('fail')
+            ->body("The health check has failed");
+    }
+}
+```
+
+### 3. Register the notification in the config file
+
+Reference your notification class and the channel in `config/health.php`.
+
+```php
+use NotificationChannels\PusherPushNotifications\Channel as PusherChannel;
+
+// ...
+'notifications' => [
+    App\Notifications\CheckFailedNotification::class => ['mail', 'slack', PusherChannel::class],
+],
+```

--- a/docs/configuring-notifications/customizing-the-notifiable.md
+++ b/docs/configuring-notifications/customizing-the-notifiable.md
@@ -1,0 +1,36 @@
+---
+title: Customizing the notifiable
+weight: 5
+---
+
+Notifications are sent to a notifiable class. The package uses
+`Spatie\Health\Notifications\Notifiable` by default. This class reads the
+configuration values from `config/health.php` to determine where
+notifications should be delivered.
+
+If your custom notification channel needs extra information you can
+extend the default notifiable and add the required routing method.
+
+```php
+namespace App\Notifications;
+
+use Spatie\Health\Notifications\Notifiable;
+
+class HealthNotifiable extends Notifiable
+{
+    public function routeNotificationForAnotherChannel()
+    {
+        return config('health.notifications.another_channel.property');
+    }
+}
+```
+
+Register your notifiable in the config file:
+
+```php
+// in config/health.php
+'notifications' => [
+    // ...
+    'notifiable' => App\Notifications\HealthNotifiable::class,
+],
+```

--- a/docs/configuring-notifications/general.md
+++ b/docs/configuring-notifications/general.md
@@ -7,9 +7,10 @@ Whenever one of the checks fails, the package can send you a notification. A not
 
 Out of the box, the notification can be sent:
 
-- via [mail](/docs/laravel-health/v1/configuring-notifications/via-mail), 
+- via [mail](/docs/laravel-health/v1/configuring-notifications/via-mail),
 - via [Slack](/docs/laravel-health/v1/configuring-notifications/via-slack)
 - via [Oh Dear](/docs/laravel-health/v1/configuring-notifications/via-oh-dear) (enables snoozing notifications, and delivery via Telegram, Discord, MS Teams, webhooks, ...)
+- or you can [add your own notification channels](/docs/laravel-health/v1/configuring-notifications/adding-extra-notification-channels)
 
 ## Throttling notifications
 


### PR DESCRIPTION
## Summary
- document how to add custom notification channels
- document how to customize the Notifiable class
- mention custom channels in the general notifications docs

## Testing
- `composer install --quiet`
- `composer test` *(fails: SQL connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687c1bb5778c832bacda80a7386700cb