### PR TITLE
Add custom notification channels

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -78,6 +78,21 @@ return [
 
             'icon' => null,
         ],
+
+        /*
+         * Here you may configure custom notification channels. The key should
+         * match the channel name as used by the notification and the value
+         * returned here will be passed to the channel.
+         *
+         * Example to use the Telegram notification channel:
+         *
+         * 'custom_channels' => [
+         *     'telegram' => env('TELEGRAM_CHAT_ID'),
+         * ],
+         */
+        'custom_channels' => [
+            // 'telegram' => env('TELEGRAM_CHAT_ID'),
+        ],
     ],
 
     /*

--- a/docs/configuring-notifications/custom-channels.md
+++ b/docs/configuring-notifications/custom-channels.md
@@ -1,0 +1,24 @@
+---
+title: Custom channels
+weight: 5
+---
+
+The `notifications.custom_channels` option in the `health` config file allows you to configure additional notification channels. The key should match the channel name and the value will be returned from the notifiable's `routeNotificationFor{Channel}` method.
+
+For example, to send notifications via Telegram you can install a notification channel such as [`laravel-notification-channels/telegram`](https://github.com/laravel-notification-channels/telegram) and configure the chat identifier:
+
+```php
+// in config/health.php
+
+'notifications' => [
+    'notifications' => [
+        Spatie\Health\Notifications\CheckFailedNotification::class => ['telegram'],
+    ],
+
+    'custom_channels' => [
+        'telegram' => env('TELEGRAM_CHAT_ID'),
+    ],
+],
+```
+
+Any value specified in `custom_channels` will be passed to the notification channel. This makes it possible to use any Laravel notification channel package without having to extend the notifiable class.

--- a/src/Notifications/Notifiable.php
+++ b/src/Notifications/Notifiable.php
@@ -3,10 +3,30 @@
 namespace Spatie\Health\Notifications;
 
 use Illuminate\Notifications\Notifiable as NotifiableTrait;
+use Illuminate\Support\Str;
 
 class Notifiable
 {
     use NotifiableTrait;
+
+    public function routeNotificationFor(string $driver, mixed $notification = null): mixed
+    {
+        if (method_exists($this, $method = 'routeNotificationFor'.Str::studly($driver))) {
+            return $this->{$method}($notification);
+        }
+
+        $customChannels = config('health.notifications.custom_channels', []);
+
+        if (array_key_exists($driver, $customChannels)) {
+            return $customChannels[$driver];
+        }
+
+        return match ($driver) {
+            'database' => $this->notifications(),
+            'mail' => $this->routeNotificationForMail(),
+            default => null,
+        };
+    }
 
     /** @return string|array<int, string> */
     public function routeNotificationForMail(): string|array

--- a/tests/Notifications/CustomNotificationChannelTest.php
+++ b/tests/Notifications/CustomNotificationChannelTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\Health\Notifications\Notifiable;
+
+it('can route custom notification channels', function () {
+    $notifiable = new Notifiable();
+
+    config()->set('health.notifications.custom_channels.telegram', '12345');
+
+    expect($notifiable->routeNotificationFor('telegram'))->toEqual('12345');
+});


### PR DESCRIPTION
## Summary
- allow configuration of custom notification channels
- support resolving custom channel routes in Notifiable
- document configuring custom channels
- add regression test for custom channels

## Testing
- `composer test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687c2144b1d4832bbb1e1b162220564a